### PR TITLE
More 3.6 compatibility fun

### DIFF
--- a/.ci-config.py
+++ b/.ci-config.py
@@ -1,0 +1,5 @@
+from daktari.checks.git import *
+
+checks = [
+    GitInstalled(),
+]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,6 @@ jobs:
     - name: mypy
       run: |
         mypy daktari
+    - name: execute git check
+      run: |
+        python3 -m daktari --debug --config .ci-config.py

--- a/daktari/command_utils.py
+++ b/daktari/command_utils.py
@@ -29,7 +29,7 @@ def run_command(command_parts):
     combined_command = " ".join(command_parts)
     logging.debug(f"Running command '{combined_command}'")
     try:
-        result = subprocess.run(command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, input='')
+        result = subprocess.run(command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     except FileNotFoundError:
         logging.debug(f"Command not found for '{combined_command}'.")
         raise CommandNotFoundException(f"Command not found: {combined_command}")

--- a/daktari/command_utils.py
+++ b/daktari/command_utils.py
@@ -29,7 +29,7 @@ def run_command(command_parts):
     combined_command = " ".join(command_parts)
     logging.debug(f"Running command '{combined_command}'")
     try:
-        result = subprocess.run(command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, input='')
     except FileNotFoundError:
         logging.debug(f"Command not found for '{combined_command}'.")
         raise CommandNotFoundException(f"Command not found: {combined_command}")

--- a/daktari/command_utils.py
+++ b/daktari/command_utils.py
@@ -29,7 +29,7 @@ def run_command(command_parts):
     combined_command = " ".join(command_parts)
     logging.debug(f"Running command '{combined_command}'")
     try:
-        result = subprocess.run(command_parts, capture_output=True, text=True)
+        result = subprocess.run(command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, input='')
     except FileNotFoundError:
         logging.debug(f"Command not found for '{combined_command}'.")
         raise CommandNotFoundException(f"Command not found: {combined_command}")
@@ -56,6 +56,7 @@ def can_run_command(command) -> bool:
         run_command(command)
         return True
     except Exception:
+        logging.debug("Exception running command", exc_info=True)
         return False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansicolors==1.1.8
 distro==1.5.0
 pyfiglet==0.7
+dataclasses==0.8; python_version < '3.7'


### PR DESCRIPTION
Use some different `subprocess` args which were around as of python3.6. The ones I've picked should be the equivalent to what we had before (see e.g. this SO post: https://stackoverflow.com/questions/53209127/subprocess-unexpected-keyword-argument-capture-output)

Also add the `dataclasses` requirement for python < 3.7 per [this SO post](https://stackoverflow.com/questions/60517042/requirements-txt-conditional-on-python-version)

Finally, add a stage to github actions to actually run daktari under the various python versions (just doing a check for git being installed, which it will be in the runners). Example failure [here](https://github.com/sonocent/daktari/runs/2609518748?check_suite_focus=true), showing that it would have caught this issue.