### PR TITLE
Add checks to misc for OS Var Validation

### DIFF
--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -115,7 +115,7 @@ class EnvVarSet(Check):
         if self.variable_value:
             return self.verify(
                 get_env_var_value(self.variable_name) == self.variable_value,
-                f"{self.variable_name} has <not/> got the expected value",
+                f"{self.variable_name} has <not/> got the required value of f{self.variable_value}",
             )
         else:
             return self.verify(check_env_var_exists(self.variable_name), f"{self.variable_name} is <not/> set")

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -106,7 +106,7 @@ class GccInstalled(Check):
 
 class EnvVarSet(Check):
     def __init__(self, variable_name: str, variable_value: Optional[str] = "", provision_command: str = ""):
-        self.name = f"env.VariableSet.{variable_name}"
+        self.name = f"env.variableSet.{variable_name}"
         self.suggestions = {OS.GENERIC: provision_command}
         self.variable_name = variable_name
         self.variable_value = variable_value

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -1,5 +1,6 @@
 from daktari.check import Check, CheckResult
-from daktari.os import OS
+from daktari.os import OS, check_env_var_exists, get_env_var_value
+from typing import Optional
 
 
 class WatchmanInstalled(Check):
@@ -101,3 +102,20 @@ class GccInstalled(Check):
 
     def check(self) -> CheckResult:
         return self.verify_install("gcc")
+
+
+class EnvVarSet(Check):
+    def __init__(self, variable_name: str, variable_value: Optional[str] = "", provision_command: str = ""):
+        self.name = f"env.VariableSet.{variable_name}"
+        self.suggestions = {OS.GENERIC: provision_command}
+        self.variable_name = variable_name
+        self.variable_value = variable_value
+
+    def check(self) -> CheckResult:
+        if self.variable_value:
+            return self.verify(
+                get_env_var_value(self.variable_name) == self.variable_value,
+                f"{self.variable_name} has <not/> got the expected value",
+            )
+        else:
+            return self.verify(check_env_var_exists(self.variable_name), f"{self.variable_name} is <not/> set")

--- a/daktari/os.py
+++ b/daktari/os.py
@@ -1,4 +1,6 @@
 import distro
+import logging
+from os import environ
 
 
 class OS:
@@ -15,3 +17,19 @@ def detect_os() -> str:
         return OS.UBUNTU
     else:
         return OS.GENERIC
+
+
+def check_env_var_exists(variable) -> bool:
+    if environ.get(variable) is not None:
+        return True
+    else:
+        logging.debug("Variable has returned empty", exc_info=True)
+        return False
+
+
+def get_env_var_value(variable) -> str:
+    if environ.get(variable) is not None:
+        return str(environ.get(variable))
+    else:
+        logging.debug("Variable is not set", exc_info=True)
+        return ""


### PR DESCRIPTION
Adds a pretty basic check for an env var being set or an env var having the correct value. 

💡 💡 💡 💡 💡 You can also pass in suggestions on how to get the right value
```
EnvVarSet(variable_name="HASHICORP_VAULT_TOKEN", provision_command="The vault token can be found by finding the old tree, near a green fence. Ask the wizard for Sasha and she will tell you the token")
```
