### PR TITLE
Add checks for OP CLI and contexts

### DIFF
--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -15,7 +15,8 @@ class OnePassInstalled(Check):
     def __init__(self, minimum_version: Optional[float] = None):
         self.minimum_version = minimum_version
         self.suggestions = {
-            OS.GENERIC: "Install OP (1Password CLI): https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool",
+            OS.GENERIC: "Install OP (1Password CLI): "
+                        "https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool",
         }
 
     def check(self) -> CheckResult:

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -5,7 +5,7 @@ import json
 
 from daktari.check import Check, CheckResult
 from daktari.command_utils import get_stdout
-from daktari.os import OS
+from daktari.os import OS, detect_os
 from pathlib import Path
 
 
@@ -16,7 +16,7 @@ class OnePassInstalled(Check):
         self.minimum_version = minimum_version
         self.suggestions = {
             OS.GENERIC: "Install OP (1Password CLI): "
-                        "https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool",
+            "https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool",
         }
 
     def check(self) -> CheckResult:

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -1,0 +1,67 @@
+import logging
+import re
+from typing import Optional
+import json
+
+from daktari.check import Check, CheckResult
+from daktari.command_utils import get_stdout
+from daktari.os import OS
+from pathlib import Path
+
+
+class OnePassInstalled(Check):
+    name = "onepass.installed"
+
+    def __init__(self, minimum_version: Optional[float] = None):
+        self.minimum_version = minimum_version
+        self.suggestions = {
+            OS.GENERIC: "Install OP (1Password CLI): https://support.1password.com/command-line-getting-started/#set-up-the-command-line-tool",
+        }
+
+    def check(self) -> CheckResult:
+        installed_version = get_op_version()
+        return self.validate_minimum_version("op", installed_version, self.minimum_version)
+
+
+version_pattern = re.compile("([0-9]+.[0-9]+)")
+
+
+def get_op_version() -> Optional[float]:
+    raw_version = get_stdout("op --version")
+    if raw_version:
+        match = version_pattern.search(raw_version)
+        if match:
+            version_string = match.group(1)
+            logging.debug(f"OP Version: {version_string}")
+            return float(version_string)
+    return None
+
+
+class OPAccountExists(Check):
+    depends_on = [OnePassInstalled]
+
+    def __init__(self, context_name: str):
+        self.context_name = context_name
+        self.name = f"op.accountExists.{context_name}"
+        self.suggestions = {
+            OS.GENERIC: f"<cmd>op signin {context_name}.onepassword.com <your-email-here></cmd>",
+        }
+
+    def check(self) -> CheckResult:
+
+        home = str(Path.home())
+        if OS.OS_X:
+            config_path = f"{home}/.op/config"
+        else:
+            config_path = f"{home}/.config/op/config"
+
+        op_config = json.loads(open(config_path).read())
+        account_json = op_config["accounts"]
+        if not account_json:
+            return self.failed("No 1Password config appears to be present on this machine.")
+
+        repo = next(filter(lambda op_contexts: op_contexts.get("shorthand") == self.context_name, account_json), None)
+        if repo is None:
+            return self.failed(f"{self.context_name} is not configured with OP CLI for the current user")
+
+        return self.passed(f"{self.context_name} is configured with OP CLI for the current user")

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -51,7 +51,7 @@ class OPAccountExists(Check):
     def check(self) -> CheckResult:
 
         home = str(Path.home())
-        if OS.OS_X:
+        if detect_os() == OS.OS_X:
             config_path = f"{home}/.op/config"
         else:
             config_path = f"{home}/.config/op/config"

--- a/daktari/file_utils.py
+++ b/daktari/file_utils.py
@@ -1,7 +1,16 @@
 from daktari.command_utils import get_stdout
+from pathlib import Path
 
 
 def is_ascii(path: str) -> bool:
     file_output = get_stdout(["file", path]) or ""
     parts = file_output.strip().split(": ")
     return parts[1] == "ASCII text"
+
+
+def file_exists(path: str) -> bool:
+    testing_file = Path(path)
+    if testing_file.is_file():
+        return True
+    else:
+        return False


### PR DESCRIPTION
➕  Check to see if the 1Password (OP) CLI is installed
➕  Add the option to check for a shorthand/context, so you can see if the user has logged into op before or not. 