### PR TITLE
Fix url and depends-on

### DIFF
--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -5,7 +5,7 @@ import json
 
 from daktari.check import Check, CheckResult
 from daktari.command_utils import get_stdout
-from daktari.os import OS, detect_os
+from daktari.os import OS
 from daktari.file_utils import file_exists
 from pathlib import Path
 

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -52,20 +52,18 @@ class OPAccountExists(Check):
     def check(self) -> CheckResult:
 
         home = str(Path.home())
-        if detect_os() == OS.OS_X:
-            config_path = f"{home}/.op/config"
-        else:
-            config_path = f"{home}/.config/op/config"
+        possible_paths = [f"{home}/.op/config", f"{home}/.config/op/config"]
 
-        if file_exists(config_path):
-            op_config = json.loads(open(config_path).read())
-            account_json = op_config["accounts"]
-            repo = next(
-                filter(lambda op_contexts: op_contexts.get("shorthand") == self.context_name, account_json), None
-            )
-            if repo is None:
-                return self.failed(f"{self.context_name} is not configured with OP CLI for the current user")
+        for config_path in possible_paths:
+            if file_exists(config_path):
+                op_config = json.loads(open(config_path).read())
+                account_json = op_config["accounts"]
+                repo = next(
+                    filter(lambda op_contexts: op_contexts.get("shorthand") == self.context_name, account_json), None
+                )
+                if repo is None:
+                    return self.failed(f"{self.context_name} is not configured with OP CLI for the current user")
 
-            return self.passed(f"{self.context_name} is configured with OP CLI for the current user")
-        else:
-            return self.failed("No 1Password config appears to be present on this machine.")
+                return self.passed(f"{self.context_name} is configured with OP CLI for the current user")
+
+        return self.failed("No 1Password config appears to be present on this machine.")

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -41,12 +41,12 @@ def get_op_version() -> Optional[float]:
 
 class OPAccountExists(Check):
     depends_on = [OnePassInstalled]
+    name = "onepass.contextExists"
 
     def __init__(self, context_name: str):
         self.context_name = context_name
-        self.name = f"op.accountExists.{context_name}"
         self.suggestions = {
-            OS.GENERIC: f"<cmd>op signin {context_name}.onepassword.com <your-email-here></cmd>",
+            OS.GENERIC: f"<cmd>op signin {context_name}.1password.com <your-email-here></cmd>",
         }
 
     def check(self) -> CheckResult:


### PR DESCRIPTION
Corrects the 1Password URL for the signin cmd. 

Also moves the name outside of `init` so we can use `depends_on = [OPAccountExists]` 