### PR TITLE
Google Cloud SDK check message

### DIFF
--- a/daktari/checks/google.py
+++ b/daktari/checks/google.py
@@ -13,7 +13,7 @@ class GoogleCloudSdkInstalled(Check):
     }
 
     def check(self) -> CheckResult:
-        return self.verify(can_run_command("gcloud --version"), "Google Cloud SDK is <not/> installed")
+        return self.verify(can_run_command("gcloud --version"), "Google Cloud SDK is <not/> installed and on $PATH")
 
 
 class CloudSqlProxyInstalled(Check):


### PR DESCRIPTION
The check for whether or not Google Cloud SDK is installed fails if it is installed but is not accessible on your $PATH. Currently, this means you can run Daktari, it will tell you Google Cloud SDK is not installed and recommend you install it, then when you try to install it you will find it's already installed, which is confusing. I've added to the message you get to prompt you that your $PATH variable might actually be the problem.