### PR TITLE
Use semver to parse required and installed Java versions, add JDK check

### DIFF
--- a/daktari/check.py
+++ b/daktari/check.py
@@ -2,6 +2,7 @@ import abc
 import re
 from dataclasses import dataclass
 from enum import Enum
+from semver import VersionInfo
 from typing import Dict, List, Optional, Type, Union
 
 from daktari.command_utils import can_run_command
@@ -66,6 +67,19 @@ class Check:
             installed_version >= minimum_version,
             f"{application} version is <not/> >={minimum_version} ({installed_version})",
         )
+
+    def validate_semver_expression(
+        self, application: str, installed_version: Optional[VersionInfo], required_version: str
+    ) -> CheckResult:
+        if installed_version is None:
+            return self.failed(f"{application} is not installed")
+
+        try:
+            version_matches = installed_version.match(required_version)
+        except ValueError as err:
+            return self.failed(f"Invalid version specification: {err}")
+
+        return self.verify(version_matches, f"{application} version is <not/> {required_version}")
 
     def verify_install(self, program: str, version_flag: str = "--version") -> CheckResult:
         return self.verify(can_run_command(f"{program} {version_flag}"), f"{program} is <not/> installed")

--- a/daktari/check.py
+++ b/daktari/check.py
@@ -79,7 +79,7 @@ class Check:
         except ValueError as err:
             return self.failed(f"Invalid version specification: {err}")
 
-        return self.verify(version_matches, f"{application} version is <not/> {required_version}")
+        return self.verify(version_matches, f"{application} version is <not/> {required_version} ({installed_version})")
 
     def verify_install(self, program: str, version_flag: str = "--version") -> CheckResult:
         return self.verify(can_run_command(f"{program} {version_flag}"), f"{program} is <not/> installed")

--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -27,7 +27,7 @@ def get_jdk_version() -> Optional[VersionInfo]:
     return parse_javac_version_output(version_output.stdout + version_output.stderr)
 
 
-def parse_java_version_output(version_output: str) -> Optional[VersionInfo]:
+def parse_java_version_output(version_output: Optional[str]) -> Optional[VersionInfo]:
     if version_output:
         match = java_version_pattern.search(version_output)
         if match:
@@ -37,13 +37,14 @@ def parse_java_version_output(version_output: str) -> Optional[VersionInfo]:
     return None
 
 
-def parse_javac_version_output(version_output: str) -> Optional[VersionInfo]:
+def parse_javac_version_output(version_output: Optional[str]) -> Optional[VersionInfo]:
     if version_output:
         match = javac_version_pattern.search(version_output)
         if match:
             version_string = match.group(1)
             logging.debug(f"JDK version string: {version_string}")
             return parse_java_version_string(version_string)
+    return None
 
 
 def parse_java_version_string(version_string: str) -> Optional[VersionInfo]:

--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from typing import Optional
+from semver import VersionInfo
 
 from daktari.check import Check, CheckResult
 from daktari.command_utils import get_stderr
@@ -11,31 +12,39 @@ one_dot_pattern = re.compile("1\\.([0-9]+)")
 other_pattern = re.compile("([0-9]+)")
 
 
-def get_java_version() -> Optional[int]:
+def get_java_version() -> Optional[VersionInfo]:
     version_output = get_stderr("java -version")
+    return parse_java_version_output(version_output)
+
+
+def parse_java_version_output(version_output: str) -> Optional[VersionInfo]:
     if version_output:
         match = java_version_pattern.search(version_output)
         if match:
             version_string = match.group(1)
             logging.debug(f"Java version string: {version_string}")
-            return get_java_number(version_string)
+            return parse_java_version_string(version_string)
     return None
 
 
-def get_java_number(version_string: str) -> Optional[int]:
+def parse_java_version_string(version_string: str) -> Optional[VersionInfo]:
+    try:
+        return VersionInfo.parse(version_string)
+    except ValueError:
+        return parse_legacy_java_number(version_string)
+
+
+def parse_legacy_java_number(version_string: str) -> Optional[int]:
     one_dot_match = one_dot_pattern.search(version_string)
     if one_dot_match:
-        return int(one_dot_match.group(1))
-    other_match = other_pattern.search(version_string)
-    if other_match:
-        return int(other_match.group(1))
+        return VersionInfo(int(one_dot_match.group(1)))
     return None
 
 
 class JavaVersion(Check):
     name = "java.version"
 
-    def __init__(self, required_version: int):
+    def __init__(self, required_version: str):
         self.required_version = required_version
 
     suggestions = {
@@ -45,4 +54,4 @@ class JavaVersion(Check):
     def check(self) -> CheckResult:
         java_version = get_java_version()
         logging.info(f"Java version: {java_version}")
-        return self.verify(java_version == self.required_version, f"Java {self.required_version} is <not/> installed")
+        return self.validate_semver_expression("Java", java_version, self.required_version)

--- a/daktari/checks/test_java.py
+++ b/daktari/checks/test_java.py
@@ -1,0 +1,48 @@
+import unittest
+
+from .java import parse_java_version_output
+from semver import VersionInfo
+
+
+class TestJava(unittest.TestCase):
+    def test_parse_non_semver_format_version(self):
+        # JRE versions prior to 9 do not use semver format
+        version_output = """openjdk version "1.8.0_292"
+OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10)
+OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
+"""
+        version = parse_java_version_output(version_output)
+        self.assertEqual(version, VersionInfo(8))
+
+    def test_parse_semver_format_version(self):
+        version_output = """openjdk version "11.0.9" 2020-10-20
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
+"""
+        version = parse_java_version_output(version_output)
+        self.assertEqual(version, VersionInfo(11, 0, 9))
+
+    def test_parse_unknown_format_version(self):
+        version_output = 'openjdk version "a.b.c"'
+        version = parse_java_version_output(version_output)
+        self.assertEqual(version, None)
+
+    def test_parse_unknown_format_output(self):
+        version_output = """
+
+Command 'java' not found, but can be installed with:
+
+sudo apt install openjdk-11-jre-headless  # version 11.0.11+9-0ubuntu2~20.04, or
+sudo apt install default-jre              # version 2:1.11-72
+sudo apt install openjdk-13-jre-headless  # version 13.0.7+5-0ubuntu1~20.04
+sudo apt install openjdk-16-jre-headless  # version 16.0.1+9-1~20.04
+sudo apt install openjdk-8-jre-headless   # version 8u292-b10-0ubuntu1~20.04
+sudo apt install openjdk-14-jre-headless  # version 14.0.2+12-1~20.04
+
+"""
+        version = parse_java_version_output(version_output)
+        self.assertEqual(version, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daktari/checks/test_java.py
+++ b/daktari/checks/test_java.py
@@ -1,6 +1,6 @@
 import unittest
 
-from .java import parse_java_version_output
+from .java import parse_java_version_output, parse_javac_version_output
 from semver import VersionInfo
 
 

--- a/daktari/checks/test_java.py
+++ b/daktari/checks/test_java.py
@@ -5,7 +5,7 @@ from semver import VersionInfo
 
 
 class TestJava(unittest.TestCase):
-    def test_parse_non_semver_format_version(self):
+    def test_parse_java_non_semver_format_version(self):
         # JRE versions prior to 9 do not use semver format
         version_output = """openjdk version "1.8.0_292"
 OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10)
@@ -14,7 +14,7 @@ OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
         version = parse_java_version_output(version_output)
         self.assertEqual(version, VersionInfo(8))
 
-    def test_parse_semver_format_version(self):
+    def test_parse_java_semver_format_version(self):
         version_output = """openjdk version "11.0.9" 2020-10-20
 OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)
 OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
@@ -22,12 +22,12 @@ OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.9+11, mixed mode)
         version = parse_java_version_output(version_output)
         self.assertEqual(version, VersionInfo(11, 0, 9))
 
-    def test_parse_unknown_format_version(self):
+    def test_parse_java_unknown_format_version(self):
         version_output = 'openjdk version "a.b.c"'
         version = parse_java_version_output(version_output)
         self.assertEqual(version, None)
 
-    def test_parse_unknown_format_output(self):
+    def test_parse_java_unknown_format_output(self):
         version_output = """
 
 Command 'java' not found, but can be installed with:
@@ -41,6 +41,37 @@ sudo apt install openjdk-14-jre-headless  # version 14.0.2+12-1~20.04
 
 """
         version = parse_java_version_output(version_output)
+        self.assertEqual(version, None)
+
+    def test_parse_javac_non_semver_format_version(self):
+        version_output = "javac 1.8.0_292\n"
+        version = parse_javac_version_output(version_output)
+        self.assertEqual(version, VersionInfo(8, 0, 0))
+
+    def test_parse_javac_semver_format_version(self):
+        version_output = "javac 11.0.9\n"
+        version = parse_javac_version_output(version_output)
+        self.assertEqual(version, VersionInfo(11, 0, 9))
+
+    def test_parse_javac_unknown_format_version(self):
+        version_output = "javac a.b.c\n"
+        version = parse_javac_version_output(version_output)
+        self.assertEqual(version, None)
+
+    def test_parse_javac_unknown_format_output(self):
+        version_output = """
+Command 'javac' not found, but can be installed with:
+
+sudo apt install openjdk-11-jdk-headless  # version 11.0.11+9-0ubuntu2~20.04, or
+sudo apt install default-jdk              # version 2:1.11-72
+sudo apt install openjdk-13-jdk-headless  # version 13.0.7+5-0ubuntu1~20.04
+sudo apt install openjdk-16-jdk-headless  # version 16.0.1+9-1~20.04
+sudo apt install openjdk-8-jdk-headless   # version 8u292-b10-0ubuntu1~20.04
+sudo apt install ecj                      # version 3.16.0-1
+sudo apt install openjdk-14-jdk-headless  # version 14.0.2+12-1~20.04
+
+"""
+        version = parse_javac_version_output(version_output)
         self.assertEqual(version, None)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ types-dataclasses==0.1.5; python_version < '3.7'
 packaging==20.9
 setuptools==56.2.0
 requests==2.26.0
+semver==2.13.0


### PR DESCRIPTION
Allows a range of required Java versions to be specified using an expression, e.g. `JavaVersion(required_version=">=11.0.0")`.

Adds a JDK version check - in Glean Doctor we check for a JRE but recommend installing the JDK if it's missing, so this gets the version from `javac` instead of `java`.