### PR TITLE
Stacktraces from bad config files will now include the source text

### DIFF
--- a/daktari/config.py
+++ b/daktari/config.py
@@ -33,7 +33,8 @@ def parse_raw_config(config_path: Path, raw_config: str) -> Optional[Config]:
 
     variables: Dict[str, Any] = {}
     try:
-        exec(raw_config, variables)
+        compiled_config = compile(raw_config, config_path, 'exec')
+        exec(compiled_config, variables)
     except Exception:
         print(red(f"❌  Failed to parse {config_path} - config is not valid."))
         logging.error(f"Exception reading {config_path}", exc_info=True)


### PR DESCRIPTION
with a .daktari.py like:
```
raise Exception('test')
```

Current:
```
ERROR:root:Exception reading .daktari.py
Traceback (most recent call last):
  File "/home/tsimpson/work/daktari/daktari/config.py", line 36, in parse_raw_config
    exec(raw_config, variables)
  File "<string>", line 1, in <module>
Exception: test
```

Patched:
```
ERROR:root:Exception reading .daktari.py
Traceback (most recent call last):
  File "/home/tsimpson/work/daktari/daktari/config.py", line 37, in parse_raw_config
    exec(compiled_config, variables)
  File ".daktari.py", line 1, in <module>
    raise Exception('test')
Exception: test
```