### PR TITLE
Add check for npm scope in yarnrc.yml

### DIFF
--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -125,18 +125,6 @@ class EnvVarSet(Check):
             return self.verify(check_env_var_exists(self.variable_name), f"{self.variable_name} is <not/> set")
 
 
-class YarnInstalled(Check):
-    name = "yarn.installed"
-
-    suggestions = {
-        OS.OS_X: "<cmd>brew install yarn</cmd>",
-        OS.GENERIC: "<cmd>npm install -g yarn</cmd>",
-    }
-
-    def check(self) -> CheckResult:
-        return self.verify_install("yarn")
-
-
 class ShfmtInstalled(Check):
     name = "shfmt.installed"
 

--- a/daktari/checks/test_yarn.py
+++ b/daktari/checks/test_yarn.py
@@ -32,7 +32,7 @@ class TestYarn(unittest.TestCase):
 
     def test_matches_scope_with_auth_token_required(self):
         template_scope = YarnNpmScope("scope", requireNpmAuthToken=True)
-        matching_yaml = {"npmAuth": "ABCD1234"}
+        matching_yaml = {"npmAuthToken": "ABCD1234"}
         non_matching_yaml = {}
 
         self.assertTrue(match_scope(template_scope, matching_yaml))

--- a/daktari/checks/test_yarn.py
+++ b/daktari/checks/test_yarn.py
@@ -1,0 +1,62 @@
+from daktari.checks.yarn import YarnNpmScope, match_scope, yarnrc_contains_scope
+import unittest
+
+TEST_SCOPE_NAME = "scope"
+TEST_REGISTRY_SERVER = "https://registry-server.glean.co"
+TEST_REGISTRY_SERVER_2 = "https://registry-server.sonocent.com"
+TEST_PUBLISH_REGISTRY = "https://publish-registry.glean.co"
+TEST_PUBLISH_REGISTRY_2 = "https://publish-registry.sonocent.com"
+TEST_AUTH_TOKEN = "ABCD1234"
+
+
+class TestYarn(unittest.TestCase):
+    def test_matches_scope_publish_registry(self):
+        template_scope = YarnNpmScope(TEST_SCOPE_NAME, TEST_PUBLISH_REGISTRY)
+        matching_yaml = {"npmPublishRegistry": TEST_PUBLISH_REGISTRY}
+        non_matching_yaml_1 = {"npmPublishRegistry": TEST_PUBLISH_REGISTRY_2}
+        non_matching_yaml_2 = {}
+
+        self.assertTrue(match_scope(template_scope, matching_yaml))
+        self.assertFalse(match_scope(template_scope, non_matching_yaml_1))
+        self.assertFalse(match_scope(template_scope, non_matching_yaml_2))
+
+    def test_matches_scope_registry_server(self):
+        template_scope = YarnNpmScope("scope", npmRegistryServer=TEST_REGISTRY_SERVER)
+        matching_yaml = {"npmRegistryServer": TEST_REGISTRY_SERVER}
+        non_matching_yaml_1 = {"npmRegistryServer": TEST_REGISTRY_SERVER_2}
+        non_matching_yaml_2 = {}
+
+        self.assertTrue(match_scope(template_scope, matching_yaml))
+        self.assertFalse(match_scope(template_scope, non_matching_yaml_1))
+        self.assertFalse(match_scope(template_scope, non_matching_yaml_2))
+
+    def test_matches_scope_with_auth_token_required(self):
+        template_scope = YarnNpmScope("scope", requireNpmAuthToken=True)
+        matching_yaml = {"npmAuth": "ABCD1234"}
+        non_matching_yaml = {}
+
+        self.assertTrue(match_scope(template_scope, matching_yaml))
+        self.assertFalse(match_scope(template_scope, non_matching_yaml))
+
+    def test_finds_scope_in_yarnrc(self):
+        yarnrc = {
+            "npmScopes": {
+                "glean": {"npmRegistryServer": TEST_REGISTRY_SERVER, "npmPublishRegistry": TEST_PUBLISH_REGISTRY},
+                "sonocent": {"npmRegistryServer": TEST_REGISTRY_SERVER_2, "npmAuth": "TOKEN"},
+            }
+        }
+        existing_scope_1 = YarnNpmScope("glean", npmPublishRegistry=TEST_PUBLISH_REGISTRY)
+        existing_scope_2 = YarnNpmScope("sonocent", npmRegistryServer=TEST_REGISTRY_SERVER_2)
+        # Incorrect scope configuration:
+        nonexistent_scope_1 = YarnNpmScope("glean", npmRegistryServer="http://localhost")
+        # Auth token required, none supplied:
+        nonexistent_scope_2 = YarnNpmScope("glean", npmRegistryServer=TEST_REGISTRY_SERVER, requireNpmAuthToken=True)
+
+        self.assertTrue(yarnrc_contains_scope(yarnrc, existing_scope_1))
+        self.assertTrue(yarnrc_contains_scope(yarnrc, existing_scope_2))
+        self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_1))
+        self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/daktari/checks/yarn.py
+++ b/daktari/checks/yarn.py
@@ -1,0 +1,99 @@
+import logging
+import os
+from typing import Any, Dict, Optional
+import yaml
+from yaml.error import YAMLError
+
+from dataclasses import dataclass
+from daktari.check import Check, CheckResult
+from daktari.file_utils import file_exists
+from daktari.os import OS
+
+
+class YarnInstalled(Check):
+    name = "yarn.installed"
+
+    suggestions = {
+        OS.OS_X: "<cmd>brew install yarn</cmd>",
+        OS.GENERIC: "<cmd>npm install -g yarn</cmd>",
+    }
+
+    def check(self) -> CheckResult:
+        return self.verify_install("yarn")
+
+
+@dataclass
+class YarnNpmScope:
+    name: str
+    npmPublishRegistry: Optional[str] = None
+    npmRegistryServer: Optional[str] = None
+    npmAlwaysAuth: Optional[bool] = None
+    requireNpmAuthToken: bool = False
+
+
+def get_yarnrc_path() -> str:
+    return os.path.expanduser("~/.yarnrc.yml")
+
+
+def get_yarnrc_suggestion(scope: YarnNpmScope) -> str:
+    scope_yaml: Dict[str, Any] = {}
+    if scope.npmRegistryServer is not None:
+        scope_yaml["npmRegistryServer"] = scope.npmRegistryServer
+    if scope.npmPublishRegistry is not None:
+        scope_yaml["npmPublishRegistry"] = scope.npmPublishRegistry
+    if scope.requireNpmAuthToken:
+        scope_yaml["npmAuthToken"] = "TOKEN"
+    if scope.npmAlwaysAuth is not None:
+        scope_yaml["npmAlwaysAuth"] = scope.npmAlwaysAuth
+    yarnrc_yaml = {"npmScopes": {scope.name: scope_yaml}}
+    return yaml.dump(yarnrc_yaml)
+
+
+def match_scope(template: YarnNpmScope, scope: Dict[str, Any]) -> bool:
+    if template.npmPublishRegistry is not None and template.npmPublishRegistry != scope.get("npmPublishRegistry", None):
+        return False
+    if template.npmRegistryServer is not None and template.npmRegistryServer != scope.get("npmRegistryServer", None):
+        return False
+    if template.npmAlwaysAuth is not None and template.npmAlwaysAuth != scope.get("npmAlwaysAuth", None):
+        return False
+    if template.requireNpmAuthToken and scope.get("npmAuthToken", "") == "":
+        return False
+    return True
+
+
+def yarnrc_contains_scope(yarnrc: Dict[str, Any], scope: YarnNpmScope) -> bool:
+    yarnrc_scopes = yarnrc.get("npmScopes", {})
+    for yarnrc_scope in yarnrc_scopes.values():
+        if match_scope(scope, yarnrc_scope):
+            return True
+    return False
+
+
+class YarnNpmScopeConfigured(Check):
+    name = "yarn.npmScopeConfigured"
+
+    def __init__(self, scope: YarnNpmScope):
+        self.scope = scope
+        self.yarnrc_suggestion = get_yarnrc_suggestion(scope)
+        self.suggestions = {
+            OS.GENERIC: f"""Add the lines below to ~/.yarnrc.yml:
+
+{self.yarnrc_suggestion}"""
+        }
+
+    def check(self) -> CheckResult:
+        yarnrc_path = get_yarnrc_path()
+        if not file_exists(yarnrc_path):
+            return self.failed("~/.yarnrc.yml does not exist")
+
+        try:
+            with open(yarnrc_path, "rb") as yarnrc_file:
+                yarnrc = yaml.safe_load(yarnrc_file)
+        except YAMLError:
+            logging.error(f"Exception reading {yarnrc_path}", exc_info=True)
+            return self.failed("Failed to parse yarnrc")
+
+        if not yarnrc_contains_scope(yarnrc, self.scope):
+            return self.failed(f"Scope {self.scope.name} not configured in yarnrc")
+
+        return self.passed(f"Scope {self.scope.name} configured in yarnrc")

--- a/daktari/config.py
+++ b/daktari/config.py
@@ -33,7 +33,7 @@ def parse_raw_config(config_path: Path, raw_config: str) -> Optional[Config]:
 
     variables: Dict[str, Any] = {}
     try:
-        compiled_config = compile(raw_config, config_path, 'exec')
+        compiled_config = compile(raw_config, config_path, "exec")
         exec(compiled_config, variables)
     except Exception:
         print(red(f"❌  Failed to parse {config_path} - config is not valid."))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ semver==2.13.0
 python-hosts==1.0.1
 tabulate==0.8.9
 types-tabulate==0.8.2
+PyYAML==5.4.1
+types-PyYAML==5.4.10


### PR DESCRIPTION
Example usage:

```
from daktari.checks.yarn import YarnNpmScope, YarnNpmScopeConfigured
```
...
```
checks = [
    YarnNpmScopeConfigured(
        YarnNpmScope(
            "glean",
            npmPublishRegistry="https://npm.pkg.github.com",
            npmRegistryServer="https://npm.pkg.github.com",
            npmAlwaysAuth=True,
            requireNpmAuthToken=True,
        )
    )
]
```