### PR TITLE
Add FilesExist check

### DIFF
--- a/daktari/checks/files.py
+++ b/daktari/checks/files.py
@@ -1,16 +1,25 @@
 from os.path import expanduser
+from typing import List
 
 from daktari.check import Check, CheckResult
 from daktari.file_utils import file_exists
 from daktari.os import OS
 
 
-class FileExists(Check):
+class FilesExist(Check):
+    name = "files.exist"
+    file_paths: List[str] = []
+    pass_fail_message = ""
+
+    def check(self) -> CheckResult:
+        files_exist = all([file_exists(expanduser(file_path)) for file_path in self.file_paths])
+        return self.verify(files_exist, self.pass_fail_message)
+
+
+class FileExists(FilesExist):
     name = "file.exists"
 
     def __init__(self, file_path: str, suggestion: str):
-        self.file_path = file_path.replace("~", expanduser("~"))
+        self.file_paths = [file_path]
+        self.pass_fail_message = f"{file_path} is <not/> present"
         self.suggestions = {OS.GENERIC: suggestion}
-
-    def check(self) -> CheckResult:
-        return self.verify(file_exists(self.file_path), f"{self.file_path} is <not/> present")


### PR DESCRIPTION
This is for checking for the existence of multiple related files.

To configure this check, the list of files is required along with pass/fail messages and suggestions, which together easily spans multiple lines, so it's inconvenient to supply them inline as arguments to `__init__()` within the list of checks (like most other checks). So here, the idea is we'd subclass the FilesExist check and write the arguments in a declarative style. For example, for the localhost certs check in Glean:

```
class LocalhostCertsGenerated(FilesExist):
    name = "localhostcerts.generated"
    file_paths = [
        "infrastructure/local-dev/certs/_wildcard.glean.localhost.com.pem",
        "infrastructure/local-dev/certs/_wildcard.glean.localhost.com-key.pem",
    ]
    pass_fail_message = "localhost certificates are <not/> present"
    suggestions = {
        OS.GENERIC: """
            Generate certificates for the fake domain names we use for local dev:
            <cmd>mkdir -p infrastructure/local-dev/certs && (cd infrastructure/local-dev/certs && mkcert '*.glean.localhost.com')</cmd>
            """
    }


checks = [
    LocalhostCertsGenerated()
]
```