### PR TITLE
Add check support for OpenJDK on Ubuntu

### DIFF
--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -10,6 +10,7 @@ from daktari.os import OS
 
 java_version_pattern = re.compile('^.*version "(.*?)".*$', re.MULTILINE)
 javac_version_pattern = re.compile("^javac (.*)$", re.MULTILINE)
+
 one_dot_pattern = re.compile("1\\.([0-9]+)")
 other_pattern = re.compile("([0-9]+)")
 
@@ -52,13 +53,16 @@ def parse_java_version_string(version_string: str) -> Optional[VersionInfo]:
     try:
         return VersionInfo.parse(version_string)
     except ValueError:
-        return parse_legacy_java_number(version_string)
+        return parse_alternative_java_version_numbers(version_string)
 
 
-def parse_legacy_java_number(version_string: str) -> Optional[int]:
+def parse_alternative_java_version_numbers(version_string: str) -> Optional[int]:
     one_dot_match = one_dot_pattern.search(version_string)
     if one_dot_match:
         return VersionInfo(int(one_dot_match.group(1)))
+    other_pattern_match = other_pattern.search(version_string)
+    if other_pattern_match:
+        return VersionInfo(int(other_pattern_match.group(1)))
     return None
 
 

--- a/daktari/checks/test_java.py
+++ b/daktari/checks/test_java.py
@@ -15,6 +15,14 @@ OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
         version = parse_java_version_output(version_output)
         self.assertEqual(version, VersionInfo(8))
 
+    def test_parse_ubuntu_openjdk_17_version(self):
+        version_output = """openjdk version "17" 2021-09-14
+OpenJDK Runtime Environment (build 17+35-Ubuntu-121.04)
+OpenJDK 64-Bit Server VM (build 17+35-Ubuntu-121.04, mixed mode, sharing)
+"""
+        version = parse_java_version_output(version_output)
+        self.assertEqual(version, VersionInfo(17, 0, 0))
+
     def test_parse_java_semver_format_version(self):
         version_output = """openjdk version "11.0.9" 2020-10-20
 OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.9+11)


### PR DESCRIPTION
Fixes previous behaviour which was to claim java was not installed.
OpenJDK in Ubuntu's repos does not use sematic versioning, instead
it outputs something like:

openjdk version "17" 2021-09-14
OpenJDK Runtime Environment (build 17+35-Ubuntu-121.04)
OpenJDK 64-Bit Server VM (build 17+35-Ubuntu-121.04, mixed mode, sharing)

I don't think theres any simple self contained way to translate the date
or  17+35-Ubuntu-121.04 to an Oracle version.

Parsing "17" as 17.0.0 is better than saying java is not installed.