### PR TITLE
Add explicit dependency on pyobjc-core 7.3 to avoid version mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ tabulate==0.8.9
 types-tabulate==0.8.2
 PyYAML==5.4.1
 types-PyYAML==5.4.10
+pyobjc-core==7.3; sys_platform == 'darwin'
 pyobjc-framework-Cocoa==7.3; sys_platform == 'darwin'
 requests-unixsocket==0.2.0
 dpath==2.0.5


### PR DESCRIPTION
Fixes:

```
RuntimeError: Wrong version of PyObjC C API (got 22, expected 21)
```