### PR TITLE
Look for more specific text in git lfs env to avoid false positive

### DIFF
--- a/daktari/checks/git.py
+++ b/daktari/checks/git.py
@@ -49,7 +49,7 @@ class GitLfsSetUpForUser(Check):
 
     def check(self) -> CheckResult:
         output = get_stdout("git lfs env")
-        passed = bool(output and "git config filter.lfs" in output)
+        passed = bool(output and "git-lfs filter-process" in output)
         return self.verify(passed, "Git LFS is <not/> set up for the current user")
 
 


### PR DESCRIPTION
On a fresh Mac, `git lfs env` seems to return:
```
git config filter.lfs.process = ""
git config filter.lfs.smudge = ""
git config filter.lfs.clean = ""
```
before `git lfs install` has been run. This PR tweak the magic text we look for to compensate.