### PR TITLE
[EE-181] Add IntelliJ plugin check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9

--- a/daktari/file_utils.py
+++ b/daktari/file_utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from daktari.command_utils import get_stdout
@@ -25,5 +26,6 @@ def file_contains_text(path: str, text: str) -> bool:
 
 
 def dir_exists(path: str) -> bool:
+    logging.debug(f"Checking if path is a directory: {path}")
     testing_dir = Path(path)
     return testing_dir.is_dir()


### PR DESCRIPTION
Generic check to see if a particular IntelliJ plugin has been installed. Motivated by wanting people to have the Detekt plugin installed in IntelliJ. Based on docs [here](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs).

I've also pinned the black pre-commit hook to a different version because it was just broken for me.