### PR TITLE
[EE-181] Detekt CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -2,13 +2,11 @@ import logging
 from typing import Dict, Optional
 
 from python_hosts import Hosts
-from semver import VersionInfo
 from tabulate import tabulate
 
 from daktari.check import Check, CheckResult
-from daktari.command_utils import get_stdout
 from daktari.os import OS, check_env_var_exists, get_env_var_value
-from daktari.version_utils import try_parse_semver
+from daktari.version_utils import get_simple_cli_version
 
 
 class WatchmanInstalled(Check):
@@ -57,19 +55,10 @@ class KtlintInstalled(Check):
         self.recommended_version = recommended_version
 
     def check(self) -> CheckResult:
-        installed_version = get_ktlint_version()
+        installed_version = get_simple_cli_version("ktlint")
         return self.validate_semver_expression(
             "ktlint", installed_version, self.required_version, self.recommended_version
         )
-
-
-def get_ktlint_version() -> Optional[VersionInfo]:
-    raw_version = get_stdout("ktlint --version")
-    if raw_version:
-        version = try_parse_semver(raw_version)
-        logging.debug(f"ktlint version: {version}")
-        return version
-    return None
 
 
 class JqInstalled(Check):
@@ -189,3 +178,34 @@ class HostAliasesConfigured(Check):
                 return self.failed(f"{hosts.hosts_path} alias {name} -> {address} not present")
 
         return self.passed(f"{hosts.hosts_path} aliases present")
+
+
+class DetektInstalled(Check):
+    name = "detekt.installed"
+
+    def __init__(
+        self,
+        required_version: Optional[str] = None,
+        recommended_version: Optional[str] = None,
+        install_version: Optional[str] = None,
+    ):
+        self.install_version = install_version
+        self.required_version = required_version
+        self.recommended_version = recommended_version
+        self.suggestions = {
+            OS.GENERIC: self.get_install_cmd(),
+        }
+
+    def get_install_cmd(self) -> str:
+        version = self.install_version or "[desired version - see https://github.com/detekt/detekt/releases]"
+        return f"""DETEKT_VERSION={version} &&
+  curl -sSLO https://github.com/detekt/detekt/releases/download/v$DETEKT_VERSION/detekt-cli-$DETEKT_VERSION.zip &&
+  unzip detekt-cli-$DETEKT_VERSION.zip &&
+  chmod +x detekt-cli-$DETEKT_VERSION/bin/detekt-cli &&
+  sudo ln -s $PWD/detekt-cli-$DETEKT_VERSION/bin/detekt-cli /usr/local/bin/detekt"""
+
+    def check(self) -> CheckResult:
+        installed_version = get_simple_cli_version("detekt")
+        return self.validate_semver_expression(
+            "detekt", installed_version, self.required_version, self.recommended_version
+        )

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -193,16 +193,23 @@ class DetektInstalled(Check):
         self.required_version = required_version
         self.recommended_version = recommended_version
         self.suggestions = {
-            OS.GENERIC: self.get_install_cmd(),
+            OS.OS_X: "brew install detekt",
+            OS.UBUNTU: self.get_linux_install_cmd(),
+            OS.GENERIC: "Install detekt: https://detekt.dev/cli.html#install-the-cli",
         }
 
-    def get_install_cmd(self) -> str:
+    def get_linux_install_cmd(self) -> str:
         version = self.install_version or "[desired version - see https://github.com/detekt/detekt/releases]"
-        return f"""DETEKT_VERSION={version} &&
-  curl -sSLO https://github.com/detekt/detekt/releases/download/v$DETEKT_VERSION/detekt-cli-$DETEKT_VERSION.zip &&
-  unzip detekt-cli-$DETEKT_VERSION.zip &&
-  chmod +x detekt-cli-$DETEKT_VERSION/bin/detekt-cli &&
-  sudo ln -s $PWD/detekt-cli-$DETEKT_VERSION/bin/detekt-cli /usr/local/bin/detekt"""
+        return f"""{{
+  DETEKT_VERSION={version}; \\
+  mkdir -p ~/.local/bin &&\\
+  cd ~/.local/bin &&\\
+  curl -sSLO https://github.com/detekt/detekt/releases/download/v$DETEKT_VERSION/detekt-cli-$DETEKT_VERSION.zip &&\\
+  unzip detekt-cli-$DETEKT_VERSION.zip &&\\
+  rm detekt-cli-$DETEKT_VERSION.zip &&\\
+  chmod +x detekt-cli-$DETEKT_VERSION/bin/detekt-cli &&\\
+  ln -s ~/.local/bin/detekt-cli-$DETEKT_VERSION/bin/detekt-cli ~/.local/bin/detekt
+}}"""
 
     def check(self) -> CheckResult:
         installed_version = get_simple_cli_version("detekt")

--- a/daktari/checks/onepassword.py
+++ b/daktari/checks/onepassword.py
@@ -1,15 +1,11 @@
 import json
-import logging
 from pathlib import Path
 from typing import Optional
 
-from semver import VersionInfo
-
 from daktari.check import Check, CheckResult
-from daktari.command_utils import get_stdout
 from daktari.file_utils import file_exists
 from daktari.os import OS
-from daktari.version_utils import try_parse_semver
+from daktari.version_utils import get_simple_cli_version
 
 
 class OnePassInstalled(Check):
@@ -24,19 +20,10 @@ class OnePassInstalled(Check):
         }
 
     def check(self) -> CheckResult:
-        installed_version = get_op_version()
+        installed_version = get_simple_cli_version("op")
         return self.validate_semver_expression(
             "1Password CLI", installed_version, self.required_version, self.recommended_version
         )
-
-
-def get_op_version() -> Optional[VersionInfo]:
-    raw_version = get_stdout("op --version")
-    if raw_version:
-        version = try_parse_semver(raw_version)
-        logging.debug(f"OP Version: {version}")
-        return version
-    return None
 
 
 class OPAccountExists(Check):

--- a/daktari/result_printer.py
+++ b/daktari/result_printer.py
@@ -42,12 +42,16 @@ def print_suggestion_text(text: str):
     raw_lines = re.compile("</?cmd>").sub("", text).splitlines()
 
     max_width = max([len(line) for line in raw_lines])
+
     title = "💡 Suggestion "
     print("┌─" + title + "─" * (max_width - len(title)) + "┐")
     for i, line in enumerate(lines):
         raw_line = raw_lines[i]
         padding = " " * (max_width - len(raw_line))
-        print(f"│ {line}{padding} │")
+        if len(raw_lines) > 1:
+            print(f"  {line}")
+        else:
+            print(f"│ {line}{padding} │")
     print("└" + "─" * (max_width + 2) + "┘")
 
 

--- a/daktari/version_utils.py
+++ b/daktari/version_utils.py
@@ -1,6 +1,18 @@
+import logging
 from typing import Optional
 
 from semver import VersionInfo
+
+from daktari.command_utils import get_stdout
+
+
+def get_simple_cli_version(binary_name: str) -> Optional[VersionInfo]:
+    raw_version = get_stdout(f"{binary_name} --version")
+    if raw_version:
+        version = try_parse_semver(raw_version)
+        logging.debug(f"{binary_name} version: {version}")
+        return version
+    return None
 
 
 def try_parse_semver(version_str: Optional[str]) -> Optional[VersionInfo]:


### PR DESCRIPTION
The Ubuntu instructions are a bit of a wall-of-text, but it's a simple copy+paste to run and ensures you end up with `detekt` rather than `detekt-cli` (the name in the zip file). I've raised an issue with the maintainers about making their manual download binary match the brew version.

I've also tweaked the result printing in this PR so that we omit the 'sides' of the box for multi-line suggestions. This means that, if they're commands, they can be much more easily copy+pasted in order to run them:

![Selection_579](https://user-images.githubusercontent.com/57534485/161999562-5c5f3e1b-f5b4-4527-b83e-411d1734dd85.png)