### PR TITLE
Add instructions option to Java version check

### DIFF
--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -73,13 +73,13 @@ class JavaVersion(Check):
         self,
         required_version: Optional[str] = None,
         recommended_version: Optional[str] = None,
-        javaInstructions: Optional[str] = None,
+        java_instructions: Optional[str] = None,
     ):
         self.required_version = required_version
         self.recommended_version = recommended_version
 
-        javaInstructionString = f"\n\n{javaInstructions}" if javaInstructions else ""
-        self.suggestions = {OS.GENERIC: f"""Install Java{javaInstructionString}"""}
+        java_instructions = f"\n\n{java_instructions}" if java_instructions else ""
+        self.suggestions = {OS.GENERIC: f"""Install Java{java_instructions}"""}
 
     def check(self) -> CheckResult:
         java_version = get_java_version()

--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -69,13 +69,17 @@ def parse_alternative_java_version_numbers(version_string: str) -> Optional[int]
 class JavaVersion(Check):
     name = "java.version"
 
-    def __init__(self, required_version: Optional[str] = None, recommended_version: Optional[str] = None):
+    def __init__(
+        self,
+        required_version: Optional[str] = None,
+        recommended_version: Optional[str] = None,
+        javaInstructions: Optional[str] = None,
+    ):
         self.required_version = required_version
         self.recommended_version = recommended_version
 
-    suggestions = {
-        OS.GENERIC: "Install Java",
-    }
+        javaInstructionString = f"\n\n{javaInstructions}" if javaInstructions else ""
+        self.suggestions = {OS.GENERIC: f"""Install Java{javaInstructionString}"""}
 
     def check(self) -> CheckResult:
         java_version = get_java_version()


### PR DESCRIPTION
Adds instructions option to Java version check. Planning to use this in Glean to link to the Java Confluence page (like Glean doctor used to) https://gleanteam.atlassian.net/wiki/spaces/DEV/pages/1082523649/Install+Java+11+JDK