### PR TITLE
Fix IntelliJ check for node package manager

### DIFF
--- a/daktari/checks/intellij_idea.py
+++ b/daktari/checks/intellij_idea.py
@@ -131,7 +131,7 @@ class IntelliJProjectImported(FilesExist):
 class IntelliJNodePackageManagerConfigured(XmlFileXPathCheck):
     name = "intellij.nodePackageManagerConfigured"
     file_path = ".idea/workspace.xml"
-    xpath_query = "./component[@name='PropertiesComponent']/property[@name='nodejs_package_manager_path']"
+    xpath_query = "./component[@name='PropertiesComponent']"
     depends_on = [IntelliJProjectImported]
 
     def __init__(self, package_manager_path: str):
@@ -146,6 +146,8 @@ class IntelliJNodePackageManagerConfigured(XmlFileXPathCheck):
         }
 
     def validate_query_result(self, result):
-        current_package_manager = None if result is None else result.attrib.get("value", None)
+        key_json = None if result is None else json.loads(result.text)
+        logging.debug(f"Raw properties json: {key_json}")
+        current_package_manager = str(key_json["keyToString"]["nodejs_package_manager_path"])
         logging.debug(f"IntelliJ node package manager set to: {current_package_manager}")
-        return current_package_manager == self.package_manager_path
+        return current_package_manager.__contains__(self.package_manager_path)


### PR DESCRIPTION
The format of the file has changed, it's now:

```
<component name="PropertiesComponent"><![CDATA[{
  "keyToString": {
    "RunOnceActivity.OpenProjectViewOnStart": "true",
    ...
    "nodejs_package_manager_path": "yarn"
  }
}]]></component>
```

Tested with my own file and the one Joss had on a Mac, and it's correctly parsing out the manager again. I've also switched it to do a contains, since mine is set up to use `~/glean/frontend/.yarn/releases/yarn-3.1.1.cjs` - the important thing for us is yarn rather than npm. 