### PR TITLE
Expand ~ when checking for dirs on $PATH

### DIFF
--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -1,4 +1,5 @@
 import logging
+from os.path import expanduser
 from typing import Dict, Optional
 
 from python_hosts import Hosts
@@ -184,10 +185,10 @@ class DirectoryIsOnPath(Check):
     name = "directory.on.path"
 
     def __init__(self, directory: str):
-        self.directory = directory
+        self.directory = expanduser(directory)  # $PATH won't auto-expand ~
         self.suggestions = {
             OS.GENERIC: "Append the following line to your profile (~/.bashrc or ~/.zshrc): "
-            f'\n\nexport PATH="{directory}:$PATH"',
+            f'\n\nexport PATH="{self.directory}:$PATH"',
         }
 
     def check(self) -> CheckResult:


### PR DESCRIPTION
It turns out adding the literal string `~/.local/bin` to your `$PATH` doesn't do any good, because ~ doesn't get expanded when it's in use. 

Therefore tweaking the daktari check so it looks for something actually helpful :sweat_smile: 